### PR TITLE
RISC-V in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Rust Project Examples and Templates for the ESP32C3
 
 This repository contains example projects that can also be used as templates written in the Rust programming language targeting the ESP32C3 by Espressif.
+ESP32C3 is a single-core Wi-Fi and Bluetooth 5 (LE) microcontroller SoC, based on the open-source RISC-V architecture. 
 
 Each of these these projects has an accompanying blog post explaining the code in more detail [here](https://apollolabsblog.hashnode.dev/). Each project also has an accompnaying Wokwi simulation.
 


### PR DESCRIPTION
There is ESP32 and there is ESP32. One expects RISC-V binaries, the other one extensa binariers. A huge difference.

The README has now "RISC-V" documented for the ESP32C3.